### PR TITLE
fix Makefile and glibc macro _GNU_SOURCE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 all: wvm
 
 CC      = gcc
-CFLAGS  = -fno-stack-protector -g
+CFLAGS  = -fno-stack-protector -g -D_GNU_SOURCE
 
 .c.o:   $(CC) $(CFLAGS) \
         -c -o $*.o $<
 
-OBJS =  jvm.o classloader.o interp_engine.o vm_error.o trace.o libelf.o safe_printf.o log.o
+OBJS =  wvm.o classloader.o interp_engine.o vm_error.o trace.o libelf.o safe_printf.o log.o slab.o garbage_collect.o
 
 wvm: $(OBJS)
 	$(CC) -o wvm $(OBJS) -lpthread

--- a/trace.c
+++ b/trace.c
@@ -63,7 +63,6 @@
 #include <sys/mman.h>
 #include <execinfo.h>
 
-#define __USE_GNU
 #include <ucontext.h>
 
 #include "trace.h"


### PR DESCRIPTION
fix Makefile bug,  and  add  slab.o garbage_collect.o ;  
use _GNU_SOURCE not __USE_GNU,  because the macro __USE_GNU is ineffective when I compile ajvm on CentOS 6.7 x86_64 platform, this is [refrence](https://gcc.gnu.org/ml/fortran/2005-10/msg00365.html). 
